### PR TITLE
core/state: Fix memory expansion bug by not copying clean objects

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -211,7 +211,7 @@ func (self *StateObject) Copy() *StateObject {
 	stateObject.codeHash = common.CopyBytes(self.codeHash)
 	stateObject.nonce = self.nonce
 	stateObject.trie = self.trie
-	stateObject.code = common.CopyBytes(self.code)
+	stateObject.code = self.code
 	stateObject.initCode = common.CopyBytes(self.initCode)
 	stateObject.storage = self.storage.Copy()
 	stateObject.remove = self.remove

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -140,10 +140,11 @@ func TestSnapshot2(t *testing.T) {
 	so0.nonce = 43
 	so0.code = []byte{'c', 'a', 'f', 'e'}
 	so0.codeHash = so0.CodeHash()
-	so0.remove = true
+	so0.remove = false
 	so0.deleted = false
-	so0.dirty = false
+	so0.dirty = true
 	state.SetStateObject(so0)
+	state.Commit()
 
 	// and one with deleted == true
 	so1 := state.GetStateObject(stateobjaddr1)
@@ -165,6 +166,7 @@ func TestSnapshot2(t *testing.T) {
 	state.Set(snapshot)
 
 	so0Restored := state.GetStateObject(stateobjaddr0)
+	so0Restored.GetState(storageaddr)
 	so1Restored := state.GetStateObject(stateobjaddr1)
 	// non-deleted is equal (restored)
 	compareStateObjects(so0Restored, so0, t)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -299,7 +299,9 @@ func (self *StateDB) Copy() *StateDB {
 	state, _ := New(common.Hash{}, self.db)
 	state.trie = self.trie
 	for k, stateObject := range self.stateObjects {
-		state.stateObjects[k] = stateObject.Copy()
+		if stateObject.dirty {
+			state.stateObjects[k] = stateObject.Copy()
+		}
 	}
 
 	state.refund.Set(self.refund)
@@ -339,7 +341,6 @@ func (s *StateDB) IntermediateRoot() common.Hash {
 				stateObject.Update()
 				s.UpdateStateObject(stateObject)
 			}
-			stateObject.dirty = false
 		}
 	}
 	return s.trie.Hash()


### PR DESCRIPTION
coded fixes to the following files, as described https://github.com/ethereum/go-ethereum/pull/3006/files

 core/state/state_object.go 
 core/state/state_test.go 
 core/state/statedb.go 
